### PR TITLE
[PLAT-495]: Implement Gorilla Mux examples

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,13 @@ go 1.15
 
 require (
 	github.com/auth0-community/go-auth0 v1.0.0
+	github.com/gorilla/mux v1.8.0
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
-	golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab // indirect
+	golang.org/x/tools v0.0.0-20201008025239-9df69603baec // indirect
 	gopkg.in/square/go-jose.v2 v2.1.7
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -300,6 +302,8 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d h1:W07d4xkoAUSNOkOzdzXCdFG
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab h1:CyH2SDm5ATQiX9gtbMYfvNNed97A9v+TJFnUX/fTaJY=
 golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201008025239-9df69603baec h1:RY2OghEV/7X1MLaecgm1mwFd3sGvUddm5pGVSxQvX0c=
+golang.org/x/tools v0.0.0-20201008025239-9df69603baec/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	go testCall()
 
-	fmt.Println("listening on :3333")
+	fmt.Println("listening on :8080")
 	mux := http.NewServeMux()
 
 	var kti service.Validator = validators.NewJWK(nil, nil, nil)

--- a/service/validators/jwk_validator_test.go
+++ b/service/validators/jwk_validator_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/bitrise-io/bitrise-oauth/service/validators"
+	"github.com/gorilla/mux"
 	"github.com/labstack/echo"
 )
 
@@ -20,6 +21,20 @@ func ExampleJWK_Middleware() {
 	log.Fatal(http.ListenAndServe(":8080", mux))
 }
 
+func ExampleJWK_MiddlewareGorillaMux() {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	router := mux.NewRouter()
+
+	validator := validators.NewJWK(nil, nil, nil)
+
+	router.Handle("/test", validator.Middleware(http.HandlerFunc(handler))).Methods(http.MethodGet)
+
+	http.Handle("/", router)
+
+	log.Fatal(http.ListenAndServe(":8080", router))
+}
+
 func ExampleJWK_HandlerFunc() {
 	handler := func(w http.ResponseWriter, r *http.Request) {}
 
@@ -30,6 +45,20 @@ func ExampleJWK_HandlerFunc() {
 	mux.HandleFunc("/test_func", validator.HandlerFunc(handler))
 
 	log.Fatal(http.ListenAndServe(":8080", mux))
+}
+
+func ExampleJWK_HandlerFuncWithGorillaMux() {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	router := mux.NewRouter()
+
+	validator := validators.NewJWK(nil, nil, nil)
+
+	router.HandleFunc("/test_func", validator.HandlerFunc(handler)).Methods(http.MethodGet)
+
+	http.Handle("/", router)
+
+	log.Fatal(http.ListenAndServe(":8080", router))
 }
 
 func ExampleJWK_ValidateRequest() {


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/PLAT-495

### What?
Two new examples implemented using [Gorilla Mux](https://github.com/gorilla/mux).

### Why?
Gorilla Mux is also one of the use-cases for this package and the new tests are demonstrating the way this package can be used in conjunction with it. 

### How?
The tests are implemented in `jwk_validator_test.go`.