### PR TITLE
[NO-JIRA]: Base realm changed

### DIFF
--- a/client/client_with_secret_test.go
+++ b/client/client_with_secret_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitrise-io/bitrise-oauth/config"
+
 	"github.com/bitrise-io/bitrise-oauth/client"
 	"github.com/bitrise-io/bitrise-oauth/mocks"
 	"github.com/stretchr/testify/assert"
@@ -162,10 +164,12 @@ func Test_GivenAnExistingHTTPContext_WhenItIsPassedAsAnOptionDuringInstantiation
 }
 
 func startMockServer(t *testing.T, mockedAuthService *mocks.AuthService, mockedClient *mocks.Client, accessToken string, tokenStatusCode, defaultStatusCode int) *httptest.Server {
+	tokenEndpointURL := "/auth/realms/" + config.Realm + "/protocol/openid-connect/token"
+
 	counter := 0
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/auth/realms/master/protocol/openid-connect/token":
+		case tokenEndpointURL:
 			w.Header().Add("content-type", "application/json")
 
 			assert.NoError(t, json.NewEncoder(w).Encode(tokenJSON{

--- a/config/config.go
+++ b/config/config.go
@@ -3,5 +3,5 @@ package config
 // ...
 const (
 	BaseURL = `https://auth.services.bitrise.io`
-	Realm   = `master`
+	Realm   = `bitrise-services`
 )

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,16 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/bitrise-oauth/config"
+	"github.com/c2fo/testify/assert"
+)
+
+func Test_DefaultConfigValues(t *testing.T) {
+	defaultBaseURL := "https://auth.services.bitrise.io"
+	assert.Equal(t, defaultBaseURL, config.BaseURL)
+
+	defaultRealm := "bitrise-services"
+	assert.Equal(t, defaultRealm, config.Realm)
+}

--- a/service/validator_test.go
+++ b/service/validator_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	auth0 "github.com/auth0-community/go-auth0"
+	"github.com/bitrise-io/bitrise-oauth/config"
 	"github.com/bitrise-io/bitrise-oauth/mocks"
 	"github.com/bitrise-io/bitrise-oauth/service"
 	"github.com/c2fo/testify/assert"
@@ -166,6 +167,8 @@ func Test_Auth0_JWKS_Caching(t *testing.T) {
 		},
 	}
 
+	certsEndpointURL := "/auth/realms/" + config.Realm + "/protocol/openid-connect/certs"
+
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			// Given
@@ -175,7 +178,7 @@ func Test_Auth0_JWKS_Caching(t *testing.T) {
 			testAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(r.URL.Path)
 				switch r.URL.Path {
-				case "/auth/realms/master/protocol/openid-connect/certs":
+				case certsEndpointURL:
 					mockAuthService.Certs()
 					addContentTypeAndTokenToResponse(w)
 				default:


### PR DESCRIPTION
### What?
Base `realm` changed to `bitrise-services`.

### Why?
`bitrise-services` realm holds the data for the services.