### PR TITLE
[PLAT-773]: Audience made configurable

### DIFF
--- a/service/audience_config.go
+++ b/service/audience_config.go
@@ -1,0 +1,17 @@
+package service
+
+// AudienceConfig ...
+type AudienceConfig struct {
+	audience []string
+}
+
+// NewAudienceConfig ...
+func NewAudienceConfig(audience string, audiences ...string) AudienceConfig {
+	return AudienceConfig{
+		audience: append(audiences, audience),
+	}
+}
+
+func (audienceConfig AudienceConfig) all() []string {
+	return audienceConfig.audience
+}

--- a/service/validator_test.go
+++ b/service/validator_test.go
@@ -187,7 +187,7 @@ func Test_Auth0_JWKS_Caching(t *testing.T) {
 			}))
 			defer testAuthServer.Close()
 
-			validator := NewValidator(WithBaseURL(testAuthServer.URL), WithKeyCacher(auth0.NewMemoryKeyCacher(testCase.expiryInSecs*time.Millisecond, 5)))
+			validator := NewValidator(NewAudienceConfig("test_audience"), WithBaseURL(testAuthServer.URL), WithKeyCacher(auth0.NewMemoryKeyCacher(testCase.expiryInSecs*time.Millisecond, 5)))
 
 			request1 := createRequestWithToken(testCase.token1)
 			request2 := createRequestWithToken(testCase.token2)
@@ -243,6 +243,7 @@ func givenMockEchoErrorWriter(err error) *mocks.ErrorWriter {
 
 func createValidator(mockJWTValidator jwtValidator) Validator {
 	validator := NewValidator(
+		NewAudienceConfig("test_audience"),
 		withValidator(mockJWTValidator),
 	)
 	return validator


### PR DESCRIPTION
### What?
`Audience` claim made configurable.

The test will be created later, by the time the `issuer` and `secret provider` are injectable in the tests.