### PR TITLE
Validator issuer claim check fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ The package offers wide configurability using Options. You can easily override a
 If you want to override the default options (like the auth service url, or the realm), you can customize the `Validator` during instantiation with Options. It's as easy as passing them as constructor parameters, separated by a comma:
 ```go
 service.NewValidator(config.NewAudienceConfig("audience"),
-  service.WithBaseURL("https://auth.services.bitrise.io"),
-	service.WithRealm("master"))
+  service.WithBaseURL("https://auth.services.bitrise.io"), service.WithRealm("master"))
 ```
 
 The available `ValidatorOption`s are the following:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ The package offers wide configurability using Options. You can easily override a
 #### ValidatorOption
 If you want to override the default options (like the auth service url, or the realm), you can customize the `Validator` during instantiation with Options. It's as easy as passing them as constructor parameters, separated by a comma:
 ```go
-service.NewValidator(service.WithBaseURL("https://authservice.bitrise.io"), service.WithRealm("master"))
+service.NewValidator(config.NewAudienceConfig("audience"),
+  service.WithBaseURL("https://auth.services.bitrise.io"),
+	service.WithRealm("master"))
 ```
 
 The available `ValidatorOption`s are the following:

--- a/service/validator.go
+++ b/service/validator.go
@@ -53,7 +53,9 @@ func NewValidator(audienceConfig config.AudienceConfig, opts ...ValidatorOption)
 		opt(serviceValidator)
 	}
 
-	serviceValidator.issuer = serviceValidator.realmURL()
+	if len(serviceValidator.issuer) == 0 {
+		serviceValidator.issuer = serviceValidator.realmURL()
+	}
 
 	if serviceValidator.secretProvider == nil {
 		serviceValidator.secretProvider = createDefaultSecretProvider(serviceValidator)

--- a/service/validator.go
+++ b/service/validator.go
@@ -49,11 +49,11 @@ func NewValidator(audienceConfig config.AudienceConfig, opts ...ValidatorOption)
 		audience:           audienceConfig,
 	}
 
-	serviceValidator.issuer = serviceValidator.realmURL()
-
 	for _, opt := range opts {
 		opt(serviceValidator)
 	}
+
+	serviceValidator.issuer = serviceValidator.realmURL()
 
 	if serviceValidator.secretProvider == nil {
 		serviceValidator.secretProvider = createDefaultSecretProvider(serviceValidator)


### PR DESCRIPTION
Setting the issuer before looping through the options caused that the issuer was always set to the default (prod auth service + bitrise-services realm), not taking the realm and base URL options into account.